### PR TITLE
Correct Debian instructions; remove out-of-place PyPi instructions

### DIFF
--- a/docs/getting-started/installation/linux.md
+++ b/docs/getting-started/installation/linux.md
@@ -4,9 +4,7 @@ title: GNS3 Linux Install
 sidebar_label: Linux
 ---
 
-## Installation from Packages
-
-### Ubuntu-based distributions (64-bit only)
+## Ubuntu-based distributions (64-bit only)
 These instructions are for Ubuntu and all distributions based on it (like Linux Mint).
 
 ```
@@ -66,42 +64,34 @@ sudo usermod -aG ubridge,libvirt,kvm,wireshark,docker $(whoami)
 
 Restart your user session by logging out and back in, or restarting the system.
 
-### Debian-based distributions (64-bit only)
+## Debian-based distributions
 
-**For Debian Jessie**
-Add the following lines to your /etc/apt/sources.list:
-```
-deb http://ppa.launchpad.net/gns3/ppa/ubuntu trusty main
-deb-src http://ppa.launchpad.net/gns3/ppa/ubuntu trusty main
+GNS3 is not available through apt; you will have to use `pipx`.
 
-sudo apt-get update
-sudo apt-get install -y gns3-gui gns3-server
-```
-
-**For Debian Stretch**
-Add the following lines to your /etc/apt/sources.list:
-```
-deb http://ppa.launchpad.net/gns3/ppa/ubuntu xenial main
-deb-src http://ppa.launchpad.net/gns3/ppa/ubuntu xenial main
-
-**The python libraries for this are broken, it will not work **
-```
-
-**For Debian Buster**
-Refresh your metadata, and install the following packages:
-```
+Refresh apt:
+```bash
 sudo apt update
-sudo apt install -y python3-pip python3-pyqt5 python3-pyqt5.qtsvg \
-python3-pyqt5.qtwebsockets \
-qemu qemu-kvm qemu-utils libvirt-clients libvirt-daemon-system virtinst \
-wireshark xtightvncviewer apt-transport-https \
-ca-certificates curl gnupg2 software-properties-common
 ```
 
-## Install GNS3 on ArchLinux Based :
-Install GNS3 on Archlinux based distros ( Arch - EndeavourOS - Garuda - ArcoLinux ) 
+Install python and the required emulation & gui packages:
+```bash
+sudo apt install python3 python3-pip pipx python3-pyqt5 python3-pyqt5.qtwebsockets python3-pyqt5.qtsvg qemu-kvm qemu-utils libvirt-clients libvirt-daemon-system virtinst dynamips software-properties-common ca-certificates curl gnupg2 
+```
 
-### Install YAY package manager:
+Use pipx to install gns3:
+```bash
+pipx install gns3-server
+pipx install gns3-gui
+```
+
+To launch the GUI, we will need to prepare the virtual environment. Inject the GNS server and QT elements:
+```bash
+pipx inject gns3-gui gns3-server PyQt5
+```
+
+Finally, launch with `gns3`.
+
+## Arch-based distributions
 
 To install GNS3 on Archlinux you will need `yay` to install from Arch Users Repository ( **AUR** ), thats if it's not already installed, to install `yay` type below command in terminal:
 
@@ -127,105 +117,6 @@ yay -S gns3-server gns3-gui
 **Finalize installation**
 
 Finally you we need to add your user to the gns3 groups as demonstrated later and do reboot. 
-
-### Install GNS3 from Pypi:
-
-```
-pip3 install gns3-server
-pip3 install gns3-gui
-```
-We’ll go ahead and install docker next.  Import the Docker GPG key:
-```
-curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
-```
-(As of 10/10/2019, Buster requires using the “edge” repo)
-```
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/debian \
-   $(lsb_release -cs) \
-   stable edge"
-```
-Refresh your metadata, and install docker:
-```
-sudo apt update
-sudo apt install -y docker-ce
-```
-Add the following lines to your /etc/apt/sources.list:
-```
-deb http://ppa.launchpad.net/gns3/ppa/ubuntu bionic main
-deb-src http://ppa.launchpad.net/gns3/ppa/ubuntu bionic main
-```
-Get the GPG key:
-```
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F88F6D313016330404F710FC9A2FD067A2E3EF7B
-```
-Refresh your metadata, and ONLY install the following two packages!
-```
-sudo apt-get update
-sudo apt install dynamips ubridge
-```
-To prevent accidentally installing anything else from that repo (for now), remove or comment out those two lines in your /etc/apt/sources.list file:
-```
-#deb http://ppa.launchpad.net/gns3/ppa/ubuntu bionic main
-#deb-src http://ppa.launchpad.net/gns3/ppa/ubuntu bionic main
-```
-You can also remove that GPG key, if desired:
-```
-sudo apt-key del F88F6D313016330404F710FC9A2FD067A2E3EF7B
-```
-Add your user to the following groups:
-
-*ubridge libvirt kvm wireshark docker*
-
-```
-sudo usermod -aG ubridge,libvirt,kvm,wireshark,docker $(whoami)
-```
-
-Restart your user session by logging out and back in, or restarting the system.
-
-
-:::note
-The reason we currently can’t just install all of the packages (except docker-ce) off launchpad, is due to a python issue
-:::
-
-
-If you have a pre-existing install of Buster, and run into the following error, follow these instructions (shout out to user Pierce Howell for providing them!)
-
-```
-Fail update installation: No module named 'sip'
-Can't import Qt modules: Qt and/or PyQt is probably not installed correctly...
-```
-
-Start by uninstalling gns3 and gns3-server (Do not remove the ppa’s):
-```
-sudo apt purge --autoremove gns3-server gns3-gui
-```
-
-Create a symbolic link for python 3.5 using python3.7:
-```
-sudo ln -s /usr/bin/python3.7 /usr/bin/python3.5
-```
-
-Install python-pip and python3-pip to use the gns3 from source:
-```sudo apt install python-pip python3-pip```
-
-Install from PyPi as listed:
-```
-sudo pip3 install gns3-server
-sudo pip3 install gns3-gui
-```
-
-Once installed, additional dependencies such as QtSvg, qtwebsockets, and dynamips will be required in order for the application to run.
-```
-sudo apt install python3-pyqt5.QtSvg python3-pyqt5.qtwebsockets dynamips
-```
-
-Finally, attempt to start gns3 from the command line. If you receive no output errors and the application does not start, try to reboot your machine.
-
-:::note
-You may not have to reboot your machine. The reboot worked in my case after much trial and error. You may also have to add the shortcut as it may not automatically populate in your applications menu.  
-:::
-
 
 ## To launch the GNS3 Server
 ```


### PR DESCRIPTION
- Corrected the Debian instructions for how to install GNS using pipx.

The previous instructions were for Jessie and Stretch (very out of date) and suggested adding PPAs, which is [_strongly_ discouraged](https://wiki.debian.org/DontBreakDebian#Don.27t_make_a_FrankenDebian). Pipx handles the virtual environment for us, as pip will not.

- Delete PyPi instructions

These included apt instructions for some reason? Perhaps it was originally aimed at Debian downstream users, but does not make sense in its own section. If we still want a separate Python-based installation section, we should adapt the pipx instructions I have included for Debian.

- Promoted all headers (removing "Installation from Packages")