### PR TITLE
Update yay installation for Arch Linux

### DIFF
--- a/docs/getting-started/installation/linux.md
+++ b/docs/getting-started/installation/linux.md
@@ -93,13 +93,31 @@ Finally, launch with `gns3`.
 
 ## Arch-based distributions
 
-To install GNS3 on Archlinux you will need `yay` to install from Arch Users Repository ( **AUR** ), thats if it's not already installed, to install `yay` type below command in terminal:
+To install GNS3 on Archlinux you will need yay to install from Arch Users Repository ( AUR ), thats if it's not already installed.
 
-```
-pacman -Syu yay 
+`yay` can be acquired either by compiling it from source or by downloading the pre-built binary version provided by GitHub Actions.
+
+For the source method:
+
+```bash
+pacman -S --needed git base-devel
+git clone https://aur.archlinux.org/yay.git
+cd yay
+makepkg -si
 ```
 
-and follow the setup process choosing the package source and confirm installation .
+For the binary option:
+
+```bash
+pacman -S --needed git base-devel
+git clone https://aur.archlinux.org/yay-bin.git
+cd yay-bin
+makepkg -si
+```
+
+Then proceed with the setup process and confirm the installation.
+
+For more detailed instructions, you can refer to the [yay repository](https://github.com/Jguer/yay).
 
 **Install Prerequesits + docker:**
 


### PR DESCRIPTION
Hi,

The previous method to install yay was not correct. `yay` can not be installed using `pacman -Syu yay` because `yay` is not in the Arch repository but only in the Arch User Repository (AUR) (by default all AUR helpers are not supported by Arch Linux, see [the related wiki page)(https://wiki.archlinux.org/title/AUR_helpers)). 

The revised instructions provide two methods: one for compiling `yay` from source and another for downloading the pre-built binary version. Also included a link to the yay repository for more detailed instructions.

Thanks for your time ! :)