### PR TITLE
Update linux.md

### DIFF
--- a/docs/getting-started/installation/linux.md
+++ b/docs/getting-started/installation/linux.md
@@ -45,7 +45,7 @@ Add the appropriate repo:
 ```
 sudo add-apt-repository \
 "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) stable"
+   $(. /etc/os-release && echo $VERSION_CODENAME) stable"
 ```
 
 Install Docker-CE:


### PR DESCRIPTION
`$(lsb_release -cs) stable `
will give issues on a few Operating Systems based on Ubuntu (Example: Linux Mint). 

`$(. /etc/os-release && echo $VERSION_CODENAME) stable `
will work the same across all Ubuntu derivative OS.
![lsb_release](https://github.com/user-attachments/assets/ac6930f2-d80d-47a9-8385-8a4257dc6065)
